### PR TITLE
Use pathlib for Unix compatibility

### DIFF
--- a/stable_diffusion_krita/sd_main.py
+++ b/stable_diffusion_krita/sd_main.py
@@ -7,13 +7,13 @@ from PyQt5.Qt import QByteArray
 from PyQt5.QtGui  import QImage, QPixmap
 import array
 from copy import copy
-from os.path import exists
+from pathlib import Path
 
 # Stable Diffusion Plugin fpr Krita
 # (C) 2022, Nicolay Mausz
 # MIT License
 #
-rPath= Krita.instance().readSetting("","ResourceDirectory","")
+rPath= Path(Krita.instance().readSetting("","ResourceDirectory",""))
 
 class ModifierData:    
     list=[]
@@ -27,11 +27,11 @@ class ModifierData:
         self.tags=obj["tags"]
     def save(self):
         str=self.serialize(self)
-        with open(rPath+"/krita_ai_modifiers.config", 'w', encoding='utf-8') as f_out:
+        with open(rPath / "krita_ai_modifiers.config", 'w', encoding='utf-8') as f_out:
             f_out.write(str)
     def load(self):
-        if (not exists(rPath+"/krita_ai_modifiers.config")): return
-        with open(rPath+"/krita_ai_modifiers.config", 'r', encoding='utf-8') as f_in:
+        if (not (rPath / "krita_ai_modifiers.config").exists()): return
+        with open(rPath / "krita_ai_modifiers.config", 'r', encoding='utf-8') as f_in:
             str=f_in.read()
         self.unserialize(self,str)    
 
@@ -75,11 +75,11 @@ class SDConfig:
         self.height=obj.get("height",512)
     def save(self):
         str=self.serialize(self)
-        with open(rPath+"/krita_ai.config", 'w', encoding='utf-8') as f_out:
+        with open(rPath / "krita_ai.config", 'w', encoding='utf-8') as f_out:
             f_out.write(str)
     def load(self):
-        if (not exists(rPath+"/krita_ai.config")): return
-        with open(rPath+"/krita_ai.config", 'r', encoding='utf-8') as f_in:
+        if (not (rPath / "krita_ai.config").exists()): return
+        with open(rPath / "krita_ai.config", 'r', encoding='utf-8') as f_in:
             str=f_in.read()
         self.unserialize(self,str)
 


### PR DESCRIPTION
I still had an issue with loading the plugin on a Linux platform. This PR ensures compatibility by using the built-in pathlib module.

Error message before fixing the bug:
```
  File "~/.local/share/krita/pykrita/stable_diffusion_krita/sd_main.py", line 782, in Config
    dlg.save()
  File "~/.local/share/krita/pykrita/stable_diffusion_krita/sd_main.py", line 186, in save
    SDConfig.save(SDConfig)
  File "~/.local/share/krita/pykrita/stable_diffusion_krita/sd_main.py", line 78, in save
    with open(rPath+"/krita_ai.config", 'w', encoding='utf-8') as f_out:
PermissionError: [Errno 13] Permission denied: '/krita_ai.config'
```
